### PR TITLE
Improve example (make use of `latex` macro), minor improvements

### DIFF
--- a/README.org
+++ b/README.org
@@ -126,14 +126,16 @@ let cap = "Number of participants in the experiment by age group. Group " &
   &"{maxGroup[\"Group\", 0]} had the most participants with {maxGroup[\"Num\", 0]}" &
   " subjects."
 # and add a reference to the table we will create 
-let figCap = cap & "The data used for the figure is found in tab. \\ref{" & $tabLab & "."
-let fig = figure(path, caption = figCap, label = figLab, width = textwidth(0.8),
+let figCap = latex:
+  "The data used for the figure is found in tab. " \ref{`tabLab`} "."
+let fig = figure(path, caption = cap & figCap, label = figLab, width = textwidth(0.8),
                  checkFile = true)
 # NOTE: The `checkFile` argument performs a runtime check on the given path to make
 # sure the file that is supposed to be put into a TeX document actually exists!
 # and finally for the table:
-let tabCap = cap & "The data is plotted in fig. \\ref{" & $figLab & "."
-let tab = toTexTable(df, caption = tabCap, label = tabLab)
+let tabCap = latex:
+  "The data is plotted in fig. " \ref{`figLab`} "."
+let tab = toTexTable(df, caption = cap & tabCap, label = tabLab)
 
 # and from here we could insert the generated TeX code directly into a TeX document.
 # We'll just print it here.

--- a/README.org
+++ b/README.org
@@ -153,7 +153,8 @@ unformatted output):
 \centering
 \includegraphics[width=0.8\textwidth]{examples/dummy_plot.png}
 \label{fig:sec:ana:participants}
-\caption{Number of participants in the experiment by age group. Group Group 2 had the most participants with 43 subjects.The data used for the figure is found in tab. \ref{tab:sec:ana:participants.}
+\caption{Number of participants in the experiment by age group. Group Group 2 had the most participants with 43 subjects.The data used for the figure is found in tab. \ref{tab:sec:ana:participants}.
+}
 
 \end{figure}
 
@@ -173,7 +174,8 @@ Num & Group\\
 \bottomrule
 \end{tabular}
 
-\caption{Number of participants in the experiment by age group. Group Group 2 had the most participants with 43 subjects.The data is plotted in fig. \ref{fig:sec:ana:participants.}
+\caption{Number of participants in the experiment by age group. Group Group 2 had the most participants with 43 subjects.The data is plotted in fig. \ref{fig:sec:ana:participants}.
+}
 \label{tab:sec:ana:participants}
 
 \end{table}

--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,8 @@
+* v0.1.2
+- improve example in README to make use of =latex= macro for the
+  captions. Why have it and not use it?
+- allow =nnkRefTy= (for =\ref=), =nnkCurly= and check commands only if
+  not a nested =nnkAccQuoted=
 * v0.1.1
 - add sugar:
   - =figure=: create TeX code for a figure, including the option to

--- a/examples/plotToTex.nim
+++ b/examples/plotToTex.nim
@@ -36,14 +36,16 @@ let cap = "Number of participants in the experiment by age group. Group " &
   &"{maxGroup[\"Group\", 0]} had the most participants with {maxGroup[\"Num\", 0]}" &
   " subjects."
 # and add a reference to the table we will create 
-let figCap = cap & "The data used for the figure is found in tab. \\ref{" & $tabLab & "."
-let fig = figure(path, caption = figCap, label = figLab, width = textwidth(0.8),
+let figCap = latex:
+  "The data used for the figure is found in tab. " \ref{`tabLab`} "."
+let fig = figure(path, caption = cap & figCap, label = figLab, width = textwidth(0.8),
                  checkFile = true)
 # NOTE: The `checkFile` argument performs a runtime check on the given path to make
 # sure the file that is supposed to be put into a TeX document actually exists!
 # and finally for the table:
-let tabCap = cap & "The data is plotted in fig. \\ref{" & $figLab & "."
-let tab = toTexTable(df, caption = tabCap, label = tabLab)
+let tabCap = latex:
+  "The data is plotted in fig. " \ref{`figLab`} "."
+let tab = toTexTable(df, caption = cap & tabCap, label = tabLab)
 
 # and from here we could insert the generated TeX code directly into a TeX document.
 # We'll just print it here.

--- a/latexdsl.nimble
+++ b/latexdsl.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.1.1"
+version       = "0.1.2"
 author        = "Vindaar"
 description   = "A DSL to write LaTeX in Nim. No idea who wants that."
 license       = "MIT"

--- a/src/latexdsl.nim
+++ b/src/latexdsl.nim
@@ -147,6 +147,7 @@ proc parseBody(n: NimNode): NimNode =
     doAssert n.len == 2
     result = toTex(n[0]) & toTex(n[1])
   of nnkRefTy:
+    ## NOTE: this corresponds to the `\ref` command.
     result = newLit"ref" & toTex(n[0])
   else:
     error("Invalid kind " & $n.kind)


### PR DESCRIPTION
Mainly fix remaining issues in the example (reference was missing a closing curly bracket) and while we're at it make use of the `latex` macro to generate the captions. 

Also introduces handling for `nnkRefTy, nnkCurly` and nested `nnkAccQuote` (to avoid checking an accented quoted string as a command)