### PR TITLE
to not expose toTexTable to Nim versions before 1.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
         run: |
           cd latexdsl
           nimble -y test
+          which nim
 
       - name: Build docs
         if: >

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [version-1-6, devel]
+        branch: [version-1-4, version-1-6, devel]
         target: [linux, macos, windows]
         include:
           - target: linux

--- a/README.org
+++ b/README.org
@@ -182,6 +182,9 @@ Num & Group\\
 \end{table}
 #+end_src
 
+*NOTE*: The Dataframe helper functionality is only available on Nim
+versions starting from v1.6!
+
 ** Caveats
 
 Of course not every possible LaTeX code can be represented as valid

--- a/docs/docs.nim
+++ b/docs/docs.nim
@@ -15,7 +15,6 @@ This file is a slightly modified version of the same file of `nimterop`:
 https://github.com/nimterop/nimterop/blob/master/nimterop/docs.nim
 ]#
 
-
 proc getNimRootDir(): string =
   #[
   hack, but works
@@ -24,7 +23,7 @@ proc getNimRootDir(): string =
   import "$nim/testament/lib/stdtest/specialpaths.nim"
   nimRootDir
   ]#
-  fmt"{currentSourcePath}".parentDir.parentDir.parentDir
+  getCurrentCompilerExe().parentDir.parentDir
 
 const
   DirSep = when defined(windows): '\\' else: '/'

--- a/latexdsl.nimble
+++ b/latexdsl.nimble
@@ -8,7 +8,7 @@ srcDir        = "src"
 
 # Dependencies
 
-requires "nim >= 1.6.0"
+requires "nim >= 1.4.0"
 requires "datamancer"
 
 import os, strutils, strformat

--- a/src/latexdsl/latex_helpers.nim
+++ b/src/latexdsl/latex_helpers.nim
@@ -78,7 +78,7 @@ func tableRow*(s: varargs[string]): string =
       result.add " & " & el
   result.add " \\\\\n"
 
-when (NimMajor, NimMinor, NimPatch) > (1, 4, 0):
+when (NimMajor, NimMinor, NimPatch) >= (1, 6, 0):
   proc toTexTable*(df: DataFrameLike,
                    caption = "",
                    label = "",

--- a/tests/tSimple.nim
+++ b/tests/tSimple.nim
@@ -177,70 +177,70 @@ when (NimMajor, NimMinor, NimPatch) >= (1, 6, 0):
     let df = seqsToDf(x, y)
     test "DF to table, no caption or label":
       let noCptNoLab = """
-  \begin{table}[htbp]
-  \centering
+\begin{table}[htbp]
+\centering
 
-  \begin{tabular}{l l}
-  \toprule
-  x & y\\
-  \midrule
-  1 & a\\
-  2 & b\\
-  3 & c\\
-  4 & d\\
-  5 & e
-  \bottomrule
-  \end{tabular}
+\begin{tabular}{l l}
+\toprule
+x & y\\
+\midrule
+1 & a\\
+2 & b\\
+3 & c\\
+4 & d\\
+5 & e
+\bottomrule
+\end{tabular}
 
 
-  \end{table}
-  """
+\end{table}
+"""
       check toTexTable(df).strip == noCptNoLab.strip
 
     test "DF to table, no label":
       let noCpt = """
-  \begin{table}[htbp]
-  \centering
+\begin{table}[htbp]
+\centering
 
-  \begin{tabular}{l l}
-  \toprule
-  x & y\\
-  \midrule
-  1 & a\\
-  2 & b\\
-  3 & c\\
-  4 & d\\
-  5 & e
-  \bottomrule
-  \end{tabular}
+\begin{tabular}{l l}
+\toprule
+x & y\\
+\midrule
+1 & a\\
+2 & b\\
+3 & c\\
+4 & d\\
+5 & e
+\bottomrule
+\end{tabular}
 
-  \caption{test caption}
+\caption{test caption}
 
-  \end{table}
-  """
+\end{table}
+"""
       check toTexTable(df, caption = "test caption").strip == noCpt.strip
 
     test "DF to table, both label and caption":
       let both = """
-  \begin{table}[htbp]
-  \centering
+\begin{table}[htbp]
+\centering
 
-  \begin{tabular}{l l}
-  \toprule
-  x & y\\
-  \midrule
-  1 & a\\
-  2 & b\\
-  3 & c\\
-  4 & d\\
-  5 & e
-  \bottomrule
-  \end{tabular}
+\begin{tabular}{l l}
+\toprule
+x & y\\
+\midrule
+1 & a\\
+2 & b\\
+3 & c\\
+4 & d\\
+5 & e
+\bottomrule
+\end{tabular}
 
-  \caption{test caption}
-  \label{testLabel}
+\caption{test caption}
+\label{testLabel}
 
-  \end{table}
-  """
+\end{table}
+"""
       check toTexTable(df, caption = "test caption",
                        label = "testLabel").strip == both.strip

--- a/tests/tSimple.nim
+++ b/tests/tSimple.nim
@@ -170,76 +170,77 @@ line 3
       \vspace{"0.5cm"} r" \\"
     check res.strip == exp.strip
 
-suite "Datamancer DF to table":
-  let x = @[1, 2, 3, 4, 5]
-  let y = @["a", "b", "c", "d", "e"]
-  let df = seqsToDf(x, y)
-  test "DF to table, no caption or label":
-    let noCptNoLab = """
-\begin{table}[htbp]
-\centering
+when (NimMajor, NimMinor, NimPath) >= (1, 6, 0):
+  suite "Datamancer DF to table":
+    let x = @[1, 2, 3, 4, 5]
+    let y = @["a", "b", "c", "d", "e"]
+    let df = seqsToDf(x, y)
+    test "DF to table, no caption or label":
+      let noCptNoLab = """
+  \begin{table}[htbp]
+  \centering
 
-\begin{tabular}{l l}
-\toprule
-x & y\\
-\midrule
-1 & a\\
-2 & b\\
-3 & c\\
-4 & d\\
-5 & e
-\bottomrule
-\end{tabular}
+  \begin{tabular}{l l}
+  \toprule
+  x & y\\
+  \midrule
+  1 & a\\
+  2 & b\\
+  3 & c\\
+  4 & d\\
+  5 & e
+  \bottomrule
+  \end{tabular}
 
 
-\end{table}
-"""
-    check toTexTable(df).strip == noCptNoLab.strip
+  \end{table}
+  """
+      check toTexTable(df).strip == noCptNoLab.strip
 
-  test "DF to table, no label":
-    let noCpt = """
-\begin{table}[htbp]
-\centering
+    test "DF to table, no label":
+      let noCpt = """
+  \begin{table}[htbp]
+  \centering
 
-\begin{tabular}{l l}
-\toprule
-x & y\\
-\midrule
-1 & a\\
-2 & b\\
-3 & c\\
-4 & d\\
-5 & e
-\bottomrule
-\end{tabular}
+  \begin{tabular}{l l}
+  \toprule
+  x & y\\
+  \midrule
+  1 & a\\
+  2 & b\\
+  3 & c\\
+  4 & d\\
+  5 & e
+  \bottomrule
+  \end{tabular}
 
-\caption{test caption}
+  \caption{test caption}
 
-\end{table}
-"""
-    check toTexTable(df, caption = "test caption").strip == noCpt.strip
+  \end{table}
+  """
+      check toTexTable(df, caption = "test caption").strip == noCpt.strip
 
-  test "DF to table, both label and caption":
-    let both = """
-\begin{table}[htbp]
-\centering
+    test "DF to table, both label and caption":
+      let both = """
+  \begin{table}[htbp]
+  \centering
 
-\begin{tabular}{l l}
-\toprule
-x & y\\
-\midrule
-1 & a\\
-2 & b\\
-3 & c\\
-4 & d\\
-5 & e
-\bottomrule
-\end{tabular}
+  \begin{tabular}{l l}
+  \toprule
+  x & y\\
+  \midrule
+  1 & a\\
+  2 & b\\
+  3 & c\\
+  4 & d\\
+  5 & e
+  \bottomrule
+  \end{tabular}
 
-\caption{test caption}
-\label{testLabel}
+  \caption{test caption}
+  \label{testLabel}
 
-\end{table}
-"""
-    check toTexTable(df, caption = "test caption",
-                     label = "testLabel").strip == both.strip
+  \end{table}
+  """
+      check toTexTable(df, caption = "test caption",
+                       label = "testLabel").strip == both.strip

--- a/tests/tSimple.nim
+++ b/tests/tSimple.nim
@@ -170,7 +170,7 @@ line 3
       \vspace{"0.5cm"} r" \\"
     check res.strip == exp.strip
 
-when (NimMajor, NimMinor, NimPath) >= (1, 6, 0):
+when (NimMajor, NimMinor, NimPatch) >= (1, 6, 0):
   suite "Datamancer DF to table":
     let x = @[1, 2, 3, 4, 5]
     let y = @["a", "b", "c", "d", "e"]


### PR DESCRIPTION
This makes the module compatible with version 1.4 again and only means a single feature is incompatible with Nim version 1.4.

In particular this means all modules that depend on LatexDSL can support 1.4 again.