### PR TITLE
add a `TeXDaemon` to process TeX commands on demand

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,15 +20,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [version-1-4, version-1-6, devel]
+        branch: [version-1-6, version-2-0, devel]
         target: [linux, macos, windows]
         include:
           - target: linux
-            builder: ubuntu-18.04
+            builder: ubuntu-latest
           - target: macos
-            builder: macos-10.15
+            builder: macos-latest
           - target: windows
-            builder: windows-2019
+            builder: windows-latest
     name: '${{ matrix.target }} (${{ matrix.branch }})'
     runs-on: ${{ matrix.builder }}
     steps:

--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,12 @@
+* v0.1.13
+- allow to hand custom output path to ~compile~
+- allow to disable ~shell~ output when compiling via ~verbose~ option
+- add ~TeXDaemon~ submodule (~latexdsl/tex_daemon.nim~) which allows
+  to spawn a TeX process, which runs in the background for you to
+  process TeX commands at will. The idea is to have a TeX compiler
+  ready on demand (without startup latency) to e.g. compute the width
+  / height / depth of a piece of text (in particular for ggplotnim's
+  TikZ backend)
 * v0.1.12
 - allow handing a custom template to ~compile~
 * v0.1.11

--- a/src/latexdsl/dsl_impl.nim
+++ b/src/latexdsl/dsl_impl.nim
@@ -52,7 +52,10 @@ proc makeArg*(arg: string): string =
 
 proc makeBeginEnd*(name, header, body: string): string =
   let headerNoName = multiReplace(header, [(name, "")])
-  let delim = MathDelim
+  when (NimMajor, NimMinor, NimPatch) > (1, 7, 0):
+    let delim = MathDelim
+  else:
+    const delim = MathDelim
   if name == "math":
     result = delim & $body & delim
   else:

--- a/src/latexdsl/dsl_impl.nim
+++ b/src/latexdsl/dsl_impl.nim
@@ -204,8 +204,16 @@ proc parseBody(n: NimNode): NimNode =
     result = result && newLit("]")
   of nnkAsgn:
     result = parseBody(n[0]) && newLit("=") && parseBody(n[1])
+  of nnkTupleConstr:
+    result = newLit("(")
+    for i, ch in n:
+      result = result && parseBody(ch)
+      if i < n.len - 1:
+        result = result && newLit(", ")
+    result = result && newLit(")")
   of nnkIdent: result = toTex(n)
   of nnkIntLit, nnkFloatLit: result = toTex(n)
+  of nnkAccQuoted: result = toTex(n)
   else:
     error("Invalid kind " & $n.kind)
 

--- a/src/latexdsl/dsl_impl.nim
+++ b/src/latexdsl/dsl_impl.nim
@@ -7,6 +7,7 @@ when NoCommandChecks.value > 0:
 else:
   import valid_tex_commands
 
+## Decides the math delimiter to use
 var MathDelim* {.compileTime.} = "$"
 
 proc `&&`(n, m: NimNode): NimNode = nnkCall.newTree(ident"&&", n, m)
@@ -51,7 +52,7 @@ proc makeArg*(arg: string): string =
 
 proc makeBeginEnd*(name, header, body: string): string =
   let headerNoName = multiReplace(header, [(name, "")])
-  const delim = MathDelim # get the *current* math delimiter
+  let delim = MathDelim
   if name == "math":
     result = delim & $body & delim
   else:

--- a/src/latexdsl/latex_compiler.nim
+++ b/src/latexdsl/latex_compiler.nim
@@ -19,9 +19,9 @@ proc getStandaloneTmpl(): string =
     document:
       "$#"
 
-proc writeTeXFile*(fname, body: string,
+proc writeTeXFile*(fname, body, tmpl: string,
                    fullBody = false) =
-  let tmpl = if fullBody: body else: getStandaloneTmpl() % body
+  let tmpl = if fullBody: body else: tmpl % body
   when nimvm:
     writeFile(fname, tmpl)
   else:
@@ -31,9 +31,19 @@ proc writeTeXFile*(fname, body: string,
 
 proc compile*(fname, body: string, tmpl = getStandaloneTmpl(),
               path = "", fullBody = false, verbose = true) =
-  # 1. write the file
-  writeTexFile(fname, body, fullBody)
+  ## Writes and compiles the file `fname` with contents `body`. If no explicit
+  ## template is given a default template including a few common packages are
+  ## included and your `body` is inserted into the `document` part. You can
+  ## hand either a custom template, which requires a `$#` field where the body
+  ## will be inserted. Or hand an entire TeX file and set `fullBody = true`.
+  ##
+  ## If `verbose` is `true`, the TeX compilation output will be printed.
+  if fname.endsWith(".pdf"):
+    echo "[WARNING] Given filename `", fname, "` ends with .pdf. This means we overwrite the temporary ",
+     ".tex file that is created!"
 
+  # 1. write the file
+  writeTexFile(fname, body, tmpl, fullBody)
 
   # get path
   let path = if path.len > 0: path else: fname.parentDir

--- a/src/latexdsl/tex_daemon.nim
+++ b/src/latexdsl/tex_daemon.nim
@@ -1,0 +1,126 @@
+import std / [osproc, streams, strutils, strscans]
+
+type
+  TeXDaemon* = object
+    pid*: Process
+    stdin*: Stream
+    stdout*: Stream
+
+proc initTexDaemon*(): TeXDaemon =
+  const cmd = "xelatex"
+  const args = ["-shell-escape"]
+  const defaultProcessOptions: set[ProcessOption] = {poStdErrToStdOut, poDaemon, poUsePath}
+  let pid = startProcess(cmd, args = args, options = defaultProcessOptions)
+  echo "Pid: ", pid.repr
+  result = TeXDaemon(pid: pid,
+                     stdin: pid.inputStream,
+                     stdout: pid.peekableOutputStream)
+
+proc write*(d: TeXDaemon, line: string) =
+  if d.pid.running:
+    d.stdin.write(line & "\n")
+    d.stdin.flush()
+  else:
+    raise newException(IOError, "The TeXDaemon is not running anymore. Write failed.")
+
+proc read*(d: TeXDaemon): string =
+  ## Reads until it encounters a `*`, which indicates the prompt of the TeX
+  ## interpreter (the first time it is two `**`). Returns all read data.
+  if d.pid.running:
+    var data = newStringOfCap(1000)
+    var c: char
+    while c != '*':
+      c = d.stdout.readChar()
+      data.add c
+    result = data
+  else:
+    raise newException(IOError, "The TeXDaemon is not running anymore. Reading failed.")
+
+proc setupForInput*(t: TeXDaemon) =
+  let d = t.read()
+  echo "TeXDaemon ready for input."
+  echo d
+  doAssert d[^1] == '*'
+
+proc process*(d: TeXDaemon, data: string) =
+  ## Processes the user data. Can be used to bring the
+  ## TeXDaemon into initial processing mode by passing
+  ## an initial setup.
+  ## This simply discards all read data.
+  for line in data.strip.splitLines:
+    echo "Writing: ", line
+    d.write(line) # write one line
+    echo "---------read"
+    echo d.read() # read back data
+    echo "-------------"
+
+const sizeCommands = """
+\typeout{\the\wd\mybox} % Width
+\typeout{\the\ht\mybox} % Height
+\typeout{\the\dp\mybox} % Depth
+"""
+
+proc checkSize(td: TeXDaemon, style, arg: string): (float, float, float) =
+  ## Checks the of the given argument if formatted by LaTeX
+  let boxArg = """$#
+\sbox{\mybox}{$#}
+""" % [style, arg]
+  td.process(boxArg)
+  # after processing write the size commands and read back the data
+  var
+    w: float
+    h: float
+    d: float
+    matched = false
+    idx = 0
+  for cmd in sizeCommands.strip.splitLines():
+    echo "Writing: ", cmd
+    td.write(cmd)
+    var res = td.read()
+    while "pt" notin res: ## If there is some more data in the stream before, make all read
+      res = td.read()
+    echo "READ: ", res
+    case idx
+    of 0: (matched, w) = res.strip().scanTuple("$fpt")
+    of 1: (matched, h) = res.strip().scanTuple("$fpt")
+    of 2: (matched, d) = res.strip().scanTuple("$fpt")
+    else: doAssert false, "Why at index : " & $idx
+    doAssert matched, "Did not match '$fpt', input was: " & $res
+    inc idx
+  result = (w, h, d)
+
+const setup = """
+\documentclass[draft]{article}
+
+\usepackage{unicode-math}
+\usepackage{amsmath}
+\usepackage{siunitx}
+\usepackage{tikz}
+
+\newbox\mybox
+\newlength\mywidth
+\newlength\myheight
+\newlength\mydepth
+
+\begin{document}
+"""
+
+let d = initTexDaemon()
+d.setupForInput()
+d.process(setup)
+
+let style = r"\fontsize{12.0}{14.4}\selectfont"
+let arg = r"\texttt{B:\ (x:\ -3.9e-07\ ,\ y:\ 0.08271)}"
+echo d.checkSize(style, arg)
+
+let style2 = r"\fontsize{16.0}{19.0}\selectfont"
+let arg2 = r"\texttt{C:\ (x:\ -3.4e-07\ ,\ y:\ 0.08271)}"
+echo d.checkSize(style2, arg2)
+
+#let data = readFile("/tmp/stuff.tex")
+#
+#for line in data.strip.splitLines:
+#  echo "Writing: ", line
+#  d.write(line) # write one line
+#  echo "---------read"
+#  echo d.read() # read back data

--- a/src/latexdsl/tex_daemon.nim
+++ b/src/latexdsl/tex_daemon.nim
@@ -2,19 +2,10 @@ import std / [osproc, streams, strutils, strscans]
 
 type
   TeXDaemon* = object
+    isReady*: bool
     pid*: Process
     stdin*: Stream
     stdout*: Stream
-
-proc initTexDaemon*(): TeXDaemon =
-  const cmd = "xelatex"
-  const args = ["-shell-escape"]
-  const defaultProcessOptions: set[ProcessOption] = {poStdErrToStdOut, poDaemon, poUsePath}
-  let pid = startProcess(cmd, args = args, options = defaultProcessOptions)
-  echo "Pid: ", pid.repr
-  result = TeXDaemon(pid: pid,
-                     stdin: pid.inputStream,
-                     stdout: pid.peekableOutputStream)
 
 proc write*(d: TeXDaemon, line: string) =
   if d.pid.running:
@@ -29,18 +20,36 @@ proc read*(d: TeXDaemon): string =
   if d.pid.running:
     var data = newStringOfCap(1000)
     var c: char
-    while c != '*':
+    while c != '*' and d.pid.running:
       c = d.stdout.readChar()
       data.add c
     result = data
   else:
     raise newException(IOError, "The TeXDaemon is not running anymore. Reading failed.")
 
-proc setupForInput*(t: TeXDaemon) =
+proc close*(td: TexDaemon) =
+  if td.isReady:
+    td.write(r"\end{document}") # this should shut down the interpreter
+    discard td.read()
+    doAssert not td.pid.running
+  else:
+    doAssert not td.pid.running
+
+proc setupForInput*(t: TeXDaemon): bool =
   let d = t.read()
-  echo "TeXDaemon ready for input."
-  echo d
-  doAssert d[^1] == '*'
+  result = d[^1] == '*'
+  echo "[INFO] TeXDaemon ready for input."
+
+proc initTexDaemon*(texCompiler = "xelatex"): TeXDaemon =
+  ## Initializes a TeX compiler to run as a daemon in the background to process
+  ## TeX commands for you at will.
+  const args = ["-shell-escape"]
+  const defaultProcessOptions: set[ProcessOption] = {poStdErrToStdOut, poDaemon, poUsePath}
+  let pid = startProcess(texCompiler, args = args, options = defaultProcessOptions)
+  result = TeXDaemon(pid: pid,
+                     stdin: pid.inputStream,
+                     stdout: pid.peekableOutputStream)
+  result.isReady = result.setupForInput()
 
 proc process*(d: TeXDaemon, data: string) =
   ## Processes the user data. Can be used to bring the
@@ -48,48 +57,13 @@ proc process*(d: TeXDaemon, data: string) =
   ## an initial setup.
   ## This simply discards all read data.
   for line in data.strip.splitLines:
-    echo "Writing: ", line
     d.write(line) # write one line
-    echo "---------read"
-    echo d.read() # read back data
-    echo "-------------"
+    discard d.read() # read back data, but discard
 
-const sizeCommands = """
-\typeout{\the\wd\mybox} % Width
-\typeout{\the\ht\mybox} % Height
-\typeout{\the\dp\mybox} % Depth
-"""
-
-proc checkSize(td: TeXDaemon, style, arg: string): (float, float, float) =
-  ## Checks the of the given argument if formatted by LaTeX
-  let boxArg = """$#
-\sbox{\mybox}{$#}
-""" % [style, arg]
-  td.process(boxArg)
-  # after processing write the size commands and read back the data
-  var
-    w: float
-    h: float
-    d: float
-    matched = false
-    idx = 0
-  for cmd in sizeCommands.strip.splitLines():
-    echo "Writing: ", cmd
-    td.write(cmd)
-    var res = td.read()
-    while "pt" notin res: ## If there is some more data in the stream before, make all read
-      res = td.read()
-    echo "READ: ", res
-    case idx
-    of 0: (matched, w) = res.strip().scanTuple("$fpt")
-    of 1: (matched, h) = res.strip().scanTuple("$fpt")
-    of 2: (matched, d) = res.strip().scanTuple("$fpt")
-    else: doAssert false, "Why at index : " & $idx
-    doAssert matched, "Did not match '$fpt', input was: " & $res
-    inc idx
-  result = (w, h, d)
-
-const setup = """
+when isMainModule:
+  let d = initTexDaemon()
+  echo d.setupForInput()
+  const setup = """
 \documentclass[draft]{article}
 
 \usepackage{unicode-math}
@@ -98,29 +72,27 @@ const setup = """
 \usepackage{tikz}
 
 \newbox\mybox
-\newlength\mywidth
-\newlength\myheight
-\newlength\mydepth
+% \newlength\mywidth
+% \newlength\myheight
+% \newlength\mydepth
 
 \begin{document}
 """
 
-let d = initTexDaemon()
-d.setupForInput()
-d.process(setup)
+  d.process(setup)
 
-let style = r"\fontsize{12.0}{14.4}\selectfont"
-let arg = r"\texttt{B:\ (x:\ -3.9e-07\ ,\ y:\ 0.08271)}"
-echo d.checkSize(style, arg)
+  let style = r"\fontsize{12.0}{14.4}\selectfont"
+  let arg = r"\texttt{B:\ (x:\ -3.9e-07\ ,\ y:\ 0.08271)}"
+  echo d.checkSize(style, arg)
 
-let style2 = r"\fontsize{16.0}{19.0}\selectfont"
-let arg2 = r"\texttt{C:\ (x:\ -3.4e-07\ ,\ y:\ 0.08271)}"
-echo d.checkSize(style2, arg2)
+  let style2 = r"\fontsize{16.0}{19.0}\selectfont"
+  let arg2 = r"\texttt{C:\ (x:\ -3.4e-07\ ,\ y:\ 0.08271)}"
+  echo d.checkSize(style2, arg2)
 
-#let data = readFile("/tmp/stuff.tex")
-#
-#for line in data.strip.splitLines:
-#  echo "Writing: ", line
-#  d.write(line) # write one line
-#  echo "---------read"
-#  echo d.read() # read back data
+  #let data = readFile("/tmp/stuff.tex")
+  #
+  #for line in data.strip.splitLines:
+  #  echo "Writing: ", line
+  #  d.write(line) # write one line
+  #  echo "---------read"
+  #  echo d.read() # read back data

--- a/tests/tMathDelim.nim
+++ b/tests/tMathDelim.nim
@@ -2,12 +2,15 @@ import unittest, strutils
 
 import ../src/latexdsl
 
-static: MathDelim = "$$"
+## NOTE: Because `MathDelim` is a {.compileTime.} variable, assigning to it at CT
+## is done without static.
+MathDelim = "$$"
 
 suite "MathDelim changed in static context":
   test "`math` delimiter can be adjusted in `static` context":
     let b = latex:
       math:
         e^{\pi i} = -1
+    echo $b.strip
     check $b.strip == r"$$e^{\pi i}=-1$$"
     echo $b

--- a/tests/tMathDelim.nim
+++ b/tests/tMathDelim.nim
@@ -4,7 +4,10 @@ import ../src/latexdsl
 
 ## NOTE: Because `MathDelim` is a {.compileTime.} variable, assigning to it at CT
 ## is done without static.
-MathDelim = "$$"
+when (NimMajor, NimMinor, NimPatch) > (1, 7, 0):
+  MathDelim = "$$"
+else:
+  static: MathDelim = "$$"
 
 suite "MathDelim changed in static context":
   test "`math` delimiter can be adjusted in `static` context":


### PR DESCRIPTION
```
* v0.1.13
- allow to hand custom output path to ~compile~
- allow to disable ~shell~ output when compiling via ~verbose~ option
- add ~TeXDaemon~ submodule (~latexdsl/tex_daemon.nim~) which allows
  to spawn a TeX process, which runs in the background for you to
  process TeX commands at will. The idea is to have a TeX compiler
  ready on demand (without startup latency) to e.g. compute the width
  / height / depth of a piece of text (in particular for ggplotnim's
  TikZ backend)
```