### PR TITLE
Fixes `verbose` argument to `compile`

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,6 @@
+* v0.1.14
+- fixes the ~verbose~ argument to ~compile~ such that it actually
+  takes effect
 * v0.1.13
 - allow to hand custom output path to ~compile~
 - allow to disable ~shell~ output when compiling via ~verbose~ option

--- a/src/latexdsl/latex_compiler.nim
+++ b/src/latexdsl/latex_compiler.nim
@@ -59,7 +59,7 @@ proc compile*(fname, body: string, tmpl = getStandaloneTmpl(),
   var generated = false
   template checkAndRun(cmd: untyped): untyped =
     var cfg = { dokCommand, dokError, dokOutput, dokRuntime }
-    if verbose:
+    if not verbose:
       cfg.excl dokOutput
     var
       res: string
@@ -67,13 +67,13 @@ proc compile*(fname, body: string, tmpl = getStandaloneTmpl(),
     when nimvm:
       (res, err) = gorgeEx(@[checkCmd, cmd].join(" "))
     else:
-      (res, err) = shellVerbose:
+      (res, err) = shellVerbose(debugConfig = cfg):
         ($checkCmd) ($cmd)
     if err == 0:
       when nimvm:
         (res, err) = gorgeEx(@[$cmd, "-output-directory", $path, $fname].join(" "))
       else:
-        (res, err) = shellVerbose:
+        (res, err) = shellVerbose(debugConfig = cfg):
           ($cmd) "-output-directory" ($path) ($fname)
       if err == 0:
         # successfully generated


### PR DESCRIPTION
Fixes the `verbose` argument of the `compile` helper proc. It wasn't taken into account (and was also inverted). 

Required for `QuietTikZ` in `ginger` / `ggplotnim`.