### PR TITLE
Add adjustments via config files for TeX compiler

### DIFF
--- a/README.org
+++ b/README.org
@@ -81,6 +81,82 @@ The compile time checks are done on:
 In case a command is not part of the =enum= yet, you can omit the CT
 check by prepending with two =\\= instead of one.
 
+** LaTeX compiler and configuration files
+
+LatexDSL comes with an interface to LaTeX compilers
+(~latexdsl/latex_compiler.nim~) to quickly compile snippets of TeX for
+you. By default it first tries to use ~lualatex~, then falls back to
+~xelatex~ and finally ~pdflatex~ if either is not found. ~lualatex~
+has the most sane font handling and can handle large TikZ files
+without problem, hence it is the default (despite being a little bit
+slower than ~xelatex~).
+
+LatexDSL uses multiple configuration files to adjust the TeX preamble
+and font settings when the LaTeX compiler is used (for example when using the
+TikZ backend of ~ggplotnim~).
+
+1. a configuration file for the common TeX preamble which should be
+   inserted into each file, ~getConfigDir() / "latexdsl" /
+   "common_preamble.tex"~. My current configuration for example looks
+   like this:
+   #+begin_src latex
+\usepackage[utf8]{inputenc}
+\usepackage{unicode-math} % for unicode support in math environments
+\usepackage{amsmath}
+\usepackage{siunitx}
+\usepackage{booktabs}
+\sisetup{mode=text,range-phrase = {\text{~to~}}, range-units=single, print-unity-mantissa=false}
+\usepackage{mhchem}
+\usepackage{tikz}
+   #+end_src
+2. Font settings for XeLaTeX can be adjusted by ~getConfigDir() / "latexdsl" /
+   "xelatex_fonts.tex"~. My current configuration for example looks
+   like this:
+   #+begin_src latex
+\usepackage{fontspec}
+\usepackage{ucharclasses}
+
+% Set main font as Latin Modern Roman (vectorized Computer Modern)
+\setmainfont{CMU Serif}[Ligatures=TeX]
+
+% Fallback font for non-ASCII characters
+\newfontfamily{\fallbackfont}{DejaVu Serif}[Ligatures=TeX]
+% And back to default
+\newfontfamily{\mainfont}{CMU Serif}[Ligatures=TeX]
+\setDefaultTransitions{\fallbackfont}{}
+   #+end_src
+   But note that handling unicode characters in this way is kind of
+   broken in my experience. Hence why I use ~lualatex~ by default.
+3. Font settings for LuaLaTeX can be adjusted by ~getConfigDir() / "latexdsl" /
+   "lualatex_fonts.tex"~. My current configuration for example looks
+   like this:
+   #+begin_src latex
+\usepackage{fontspec}
+
+\directlua{
+  luaotfload.add_fallback(
+  "FallbackFonts",
+  {
+        "DejaVu Serif:mode=harf;",
+        "DejaVu Sans Mono:mode=harf;",
+        % we could add many more fonts here optionally!
+    }
+  )
+}
+
+\setmainfont{CMU Serif}[RawFeature={fallback=FallbackFonts}]
+\setmonofont{Inconsolata}[RawFeature={fallback=FallbackFonts}]
+   #+end_src
+
+These configuration snippets will be inserted into your preamble
+automatically if you run the ~compile~ command. Defaults similar to
+the above are used if no configuration files exist.
+
+*NOTE*: Because the font settings are compiler specific they need to
+be spliced into the TeX body given to the ~compile~ command. It
+replaces ~\begin{document}~ by the font settings and
+~\begin{document}~.
+   
 ** An example of available sugar
 
 Without making this example more complicated than necessary, let's

--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,10 @@
+* v0.2.0
+- ~DEBUG_TEX~ can be set as an environment variable to overwrite the
+  verbosity setting of the LaTeX compiler
+- the priority of the LaTeX compilers was changed to prefer LuaLaTeX
+  over XeLaTeX due to its saner font handling
+- adds three configuration files, for the preamble and XeLaTeX and
+  LuaLaTeX font settings (see README)
 * v0.1.14
 - fixes the ~verbose~ argument to ~compile~ such that it actually
   takes effect

--- a/changelog.org
+++ b/changelog.org
@@ -5,6 +5,7 @@
   over XeLaTeX due to its saner font handling
 - adds three configuration files, for the preamble and XeLaTeX and
   LuaLaTeX font settings (see README)
+- other minor fixes
 * v0.1.14
 - fixes the ~verbose~ argument to ~compile~ such that it actually
   takes effect

--- a/src/latexdsl/dsl_impl.nim
+++ b/src/latexdsl/dsl_impl.nim
@@ -227,7 +227,7 @@ proc toTex(n: NimNode): NimNode =
   of nnkAccQuoted: result = nnkCall.newTree(ident"$", n[0])
   of nnkIdent, nnkStrLit, nnkTripleStrLit, nnkRStrLit:
     let nStr = n.strVal
-    result = if nStr == "\\\\": newLit "\\" else: newLit nStr
+    result = if nStr == "\\\\": newLit r"\\" else: newLit nStr
   of nnkIntLit, nnkFloatLit: result = n.toStrLit
   of nnkNilLit: result = newLit ""
   of nnkCall:

--- a/src/latexdsl/latex_compiler.nim
+++ b/src/latexdsl/latex_compiler.nim
@@ -10,7 +10,7 @@ import pkg / shell
 const cfgPreamble = "common_preamble.tex"
 const cfgXeLaTeX = "xelatex_fonts.tex"
 const cfgLuaLaTeX = "lualatex_fonts.tex"
-func f(fn: string): string = getConfigDir() / "latexdsl" / fn
+proc f(fn: string): string = getConfigDir() / "latexdsl" / fn
 ## These define the used preamble and font settings based on files in the users
 ## configuration directory. If they don't exist we use the hardcoded values from
 ## below.

--- a/src/latexdsl/latex_compiler.nim
+++ b/src/latexdsl/latex_compiler.nim
@@ -87,7 +87,10 @@ proc writeTeXFile*(fname, body, tmpl: string,
     f.write(tmpl)
     f.close()
 
-import std / [envvars, strutils]
+when (NimMajor, NimMinor, NimPatch) >= (2, 0, 0):
+  import std / [envvars, strutils]
+else:
+  import std / [os, strutils]
 proc compile*(fname, body: string, tmpl = getStandaloneTmpl(),
               path = "", fullBody = false, verbose = true) =
   ## Writes and compiles the file `fname` with contents `body`. If no explicit

--- a/src/latexdsl/latex_compiler.nim
+++ b/src/latexdsl/latex_compiler.nim
@@ -116,9 +116,9 @@ proc compile*(fname, body: string, tmpl = getStandaloneTmpl(),
 
   var generated = false
   template checkAndRun(cmd: untyped): untyped =
-    var cfg = { dokCommand, dokError, dokOutput, dokRuntime }
-    if not verbose:
-      cfg.excl dokOutput
+    var cfg = { dokCommand, dokError, dokRuntime }
+    if verbose:
+      cfg.incl dokOutput
     var
       res: string
       err: int

--- a/src/latexdsl/tex_daemon.nim
+++ b/src/latexdsl/tex_daemon.nim
@@ -31,7 +31,9 @@ proc close*(td: TexDaemon) =
   if td.isReady:
     td.write(r"\end{document}") # this should shut down the interpreter
     discard td.read()
-    doAssert not td.pid.running
+    if td.pid.running:
+      terminate(td.pid)
+    #doAssert not td.pid.running
   else:
     doAssert not td.pid.running
 

--- a/src/latexdsl/tex_daemon.nim
+++ b/src/latexdsl/tex_daemon.nim
@@ -1,5 +1,8 @@
 import std / [osproc, streams, strutils, strscans]
 
+from std / os import getEnv
+var DebugTexDaemon = getEnv("DEBUG_TEX", "false").parseBool
+
 type
   TeXDaemon* = object
     isReady*: bool
@@ -9,6 +12,8 @@ type
 
 proc write*(d: TeXDaemon, line: string) =
   if d.pid.running:
+    if DebugTexDaemon:
+      echo "Writing: ", line
     d.stdin.write(line & "\n")
     d.stdin.flush()
   else:
@@ -24,6 +29,8 @@ proc read*(d: TeXDaemon): string =
       c = d.stdout.readChar()
       data.add c
     result = data
+    if DebugTexDaemon:
+      echo "Read: ", result
   else:
     raise newException(IOError, "The TeXDaemon is not running anymore. Reading failed.")
 

--- a/src/latexdsl/tex_daemon.nim
+++ b/src/latexdsl/tex_daemon.nim
@@ -59,7 +59,7 @@ proc process*(d: TeXDaemon, data: string) =
   ## an initial setup.
   ## This simply discards all read data.
   for line in data.strip.splitLines:
-    d.write(line) # write one line
+    d.write(line.strip) # write one line
     discard d.read() # read back data, but discard
 
 when isMainModule:

--- a/tests/tSimple.nim
+++ b/tests/tSimple.nim
@@ -67,7 +67,7 @@ suite "LaTeX DSL simple tests":
       \documentclass{article}
       \usepackage[`lang`]{babel}
       \usepackage[utf8]{inputenc}
-      \\newcolumntype{Y}{r">{\raggedleft\arraybackslash}X"}
+      \newcolumntype{Y}{r">{\raggedleft\arraybackslash}X"}
 
     check res == exp2
 


### PR DESCRIPTION
When using the TeX compiler we read different config files now for a common preamble and font settings. See the new README section. This is important (and used) by upcoming `ginger` and `ggplotnim`.

```
* v0.2.0
- ~DEBUG_TEX~ can be set as an environment variable to overwrite the
  verbosity setting of the LaTeX compiler
- the priority of the LaTeX compilers was changed to prefer LuaLaTeX
  over XeLaTeX due to its saner font handling
- adds three configuration files, for the preamble and XeLaTeX and
  LuaLaTeX font settings (see README)
```