### PR TITLE
Support doc comments & complex quoting

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,13 @@
+* v0.2.1
+- support Nim doc comments and turn them into LaTeX comments
+- support complex expressions in a quote, i.e. `x.foo.bar`.
+  *Note*: *Only* dot expressions are supported. Call or command syntax
+  are not allowed!
+- *Potentially breaking* (unlikely): If you used the ~compile~ helper
+  with ~fullBody = true~, previously it injected a ~\begin/end
+  document~ around the given body. That is not really very useful, if
+  one wants to pass a full TeX file to compile including header and
+  everything. 
 * v0.2.0
 - ~DEBUG_TEX~ can be set as an environment variable to overwrite the
   verbosity setting of the LaTeX compiler

--- a/latexdsl.nimble
+++ b/latexdsl.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.2.0"
+version       = "0.2.1"
 author        = "Vindaar"
 description   = "A DSL to write LaTeX in Nim. No idea who wants that."
 license       = "MIT"

--- a/src/latexdsl/dsl_impl.nim
+++ b/src/latexdsl/dsl_impl.nim
@@ -218,6 +218,8 @@ proc parseBody(n: NimNode): NimNode =
   of nnkIdent: result = toTex(n)
   of nnkIntLit, nnkFloatLit: result = toTex(n)
   of nnkAccQuoted: result = toTex(n)
+  of nnkCommentStmt: result = toTex(n)
+  #of nnkPar: result = toTex(n)
   else:
     error("Invalid kind " & $n.kind)
 
@@ -237,6 +239,11 @@ proc toTex(n: NimNode): NimNode =
       result = n
     else:
       result = parseBody(n)
+  of nnkCommentStmt:
+    var cmt: string
+    for el in n.strVal.splitLines:
+      cmt.add "%" & el
+    result = newLit(cmt)
   else: result = parseBody(n)
 
 proc unsym(n: NimNode): NimNode =

--- a/src/latexdsl/latex_compiler.nim
+++ b/src/latexdsl/latex_compiler.nim
@@ -137,7 +137,9 @@ proc compile*(fname, body: string, tmpl = getStandaloneTmpl(),
         of "xelatex": xelatexFontSettings()
         of "lualatex": lualatexFontSettings()
         else: ""
-      let body = body.replace(r"\begin{document}", fontSettings & "\n" & r"\begin{document}")
+      var body = body
+      if not fullBody:
+        body = body.replace(r"\begin{document}", fontSettings & "\n" & r"\begin{document}")
       # 2. write the TeX file with injected body
       writeTexFile(fname, body, tmpl, fullBody)
       when nimvm:

--- a/src/latexdsl/latex_helpers.nim
+++ b/src/latexdsl/latex_helpers.nim
@@ -8,8 +8,8 @@ type
     $v is string
   DataFrameLike* = concept df
     df.getKeys() is seq[string]
-    df.row(int) is ValueLike
-    df.len is int
+    df.row(system.int) is ValueLike
+    df.len is system.int
 
   AlignmentKind* = enum
     akNone = ""


### PR DESCRIPTION
```
* v0.2.1
- support Nim doc comments and turn them into LaTeX comments
- support complex expressions in a quote, i.e. `x.foo.bar`.
  *Note*: *Only* dot expressions are supported. Call or command syntax
  are not allowed!
- *Potentially breaking* (unlikely): If you used the ~compile~ helper
  with ~fullBody = true~, previously it injected a ~\begin/end
  document~ around the given body. That is not really very useful, if
  one wants to pass a full TeX file to compile including header and
  everything. 
```