### PR TITLE
Support JavaScript as a target, fixes #16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
       - 'docs/**'
       - 'latexdsl.nimble'
       - '.github/workflows/ci.yml'
+    branches:
+      - 'master'
   pull_request:
     paths:
       - 'tests/**'

--- a/latexdsl.nimble
+++ b/latexdsl.nimble
@@ -32,6 +32,10 @@ when canImport(docs / docs):
 task test, "Run the tests":
   exec "nim r tests/tSimple.nim"
   exec "nim r tests/tMathDelim.nim"
+  # run on JS target
+  exec "nim js -r tests/tSimple.nim"
+  exec "nim js -r tests/tMathDelim.nim"
+
 
 task testDeps, "Installs dependencies for tests":
   exec "nimble install -y datamancer"

--- a/src/latexdsl.nim
+++ b/src/latexdsl.nim
@@ -2,8 +2,11 @@ import macrocache
 # keep the value at 0 to get proper CT checks!
 const NoCommandChecks = CacheCounter"CommandCounterCheck"
 
-import latexdsl / [dsl_impl, latex_helpers, latex_compiler, valid_tex_commands]
+import latexdsl / [dsl_impl, latex_helpers, valid_tex_commands]
 export dsl_impl,
        valid_tex_commands,
-       latex_helpers,
-       latex_compiler
+       latex_helpers
+
+when not defined(js):
+  import latexdsl / latex_compiler
+  export latex_compiler

--- a/src/latexdsl/dsl_impl.nim
+++ b/src/latexdsl/dsl_impl.nim
@@ -58,7 +58,10 @@ proc makeBeginEnd*(name, header, body: string): string =
   when (NimMajor, NimMinor, NimPatch) > (1, 7, 0):
     let delim = MathDelim
   else:
-    const delim = MathDelim
+    when not defined(js):
+      const delim = MathDelim
+    else:
+      let delim = MathDelim
   if name == "math":
     result = delim & $body & delim
   else:

--- a/src/latexdsl/dsl_impl.nim
+++ b/src/latexdsl/dsl_impl.nim
@@ -8,7 +8,10 @@ else:
   import valid_tex_commands
 
 ## Decides the math delimiter to use
-var MathDelim* {.compileTime.} = "$"
+when not defined(js):
+  var MathDelim* {.compileTime.} = "$"
+else: # on the JS backend a compileTime variable causes an ICE
+  var MathDelim* = "$" # runtime variable
 
 proc `&&`(n, m: NimNode): NimNode = nnkCall.newTree(ident"&&", n, m)
 

--- a/src/latexdsl/latex_helpers.nim
+++ b/src/latexdsl/latex_helpers.nim
@@ -1,4 +1,6 @@
-import os, strutils, sequtils
+import std/[strutils, sequtils]
+when not defined(js):
+  import std/os # for fileExsits
 
 import dsl_impl, valid_tex_commands
 
@@ -50,9 +52,10 @@ proc figure*(path: string,
                "height=" & height
              else:
                raise newException(ValueError, "Please hand either a width or a height!")
-  if checkFile:
-    doAssert fileExists(path), "The file " & $path & " for which to generate TeX " &
-      "doesn't exist yet!"
+  when not defined(js):
+    if checkFile:
+      doAssert fileExists(path), "The file " & $path & " for which to generate TeX " &
+        "doesn't exist yet!"
   var mainBody = latex:
     \centering
     \includegraphics[`size`]{`path`}

--- a/tests/tMathDelim.nim
+++ b/tests/tMathDelim.nim
@@ -2,12 +2,15 @@ import unittest, strutils
 
 import ../src/latexdsl
 
-## NOTE: Because `MathDelim` is a {.compileTime.} variable, assigning to it at CT
-## is done without static.
-when (NimMajor, NimMinor, NimPatch) > (1, 7, 0):
-  MathDelim = "$$"
+when not defined(js):
+  ## NOTE: Because `MathDelim` is a {.compileTime.} variable, assigning to it at CT
+  ## is done without static.
+  when (NimMajor, NimMinor, NimPatch) > (1, 7, 0):
+    MathDelim = "$$"
+  else:
+    static: MathDelim = "$$"
 else:
-  static: MathDelim = "$$"
+  MathDelim = "$$" # runtime variable
 
 suite "MathDelim changed in static context":
   test "`math` delimiter can be adjusted in `static` context":

--- a/tests/tSimple.nim
+++ b/tests/tSimple.nim
@@ -177,13 +177,14 @@ line 3
         e^{\pi i} = -1
     check $b.strip == r"$e^{\pi i}=-1$"
 
-  test "`latex` can be used in CT context":
-    const b = latex:
-      math:
-        e^{\pi i} = -1
-    static:
-      echo $b
-      doAssert $b.strip == r"$e^{\pi i}=-1$", " was ? " & $b
+  when not defined(js):
+    test "`latex` can be used in CT context":
+      const b = latex:
+        math:
+          e^{\pi i} = -1
+      static:
+        echo $b
+        doAssert $b.strip == r"$e^{\pi i}=-1$", " was ? " & $b
 
   test "`latex` can be used inside a template (unsym)":
     template nbMath(body: untyped): untyped =

--- a/tests/tSimple.nim
+++ b/tests/tSimple.nim
@@ -103,11 +103,12 @@ suite "LaTeX DSL simple tests":
     doAssertRaises(ValueError):
       let res = figure(path, caption)
 
-  test "Checking for file in `figure` works as expected":
-    let path = "/tmp/my_figure.pdf"
-    let caption = "A fancy plot it is!"
-    doAssertRaises(AssertionError):
-      let res = figure(path, caption, width = textwidth(0.8), checkFile = true)
+  when not defined(js):
+    test "Checking for file in `figure` works as expected":
+      let path = "/tmp/my_figure.pdf"
+      let caption = "A fancy plot it is!"
+      doAssertRaises(AssertionError):
+        let res = figure(path, caption, width = textwidth(0.8), checkFile = true)
 
   test "Multiline `{}` using pragma syntax":
     let exp = """


### PR DESCRIPTION
The JS target comes with 2 restrictions:
- obviously no LaTeX compiler
- cannot be used at compile time with JS target (we could make this work, but without having the math delimiter adjustable then)

Otherwise it should now behave as the C target.