### PR TITLE
suggestion: for loop support

### DIFF
--- a/latexdsl.nimble
+++ b/latexdsl.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.2.2"
+version       = "0.2.3"
 author        = "Vindaar"
 description   = "A DSL to write LaTeX in Nim. No idea who wants that."
 license       = "MIT"

--- a/src/latexdsl/dsl_impl.nim
+++ b/src/latexdsl/dsl_impl.nim
@@ -318,4 +318,4 @@ macro latex*(body: untyped): untyped =
     block:
       `result`
       `res`
-  echo result.repr
+  #echo result.repr

--- a/src/latexdsl/dsl_impl.nim
+++ b/src/latexdsl/dsl_impl.nim
@@ -226,6 +226,15 @@ proc parseBody(n: NimNode): NimNode =
   of nnkAccQuoted: result = toTex(n)
   of nnkCommentStmt: result = toTex(n)
   #of nnkPar: result = toTex(n)
+  of nnkForStmt:
+    var n = n
+    let tmp = genSym(nskVar, "tmp")
+    n[^1] = newAssignment(tmp, tmp && toTex(n[^1]))
+    result = quote do:
+      block:
+        var `tmp`: string
+        `n`
+        `tmp`
   else:
     error("Invalid kind " & $n.kind)
 
@@ -309,4 +318,4 @@ macro latex*(body: untyped): untyped =
     block:
       `result`
       `res`
-  #echo result.repr
+  echo result.repr

--- a/src/latexdsl/valid_tex_commands.nim
+++ b/src/latexdsl/valid_tex_commands.nim
@@ -51,7 +51,7 @@ type
     makeglossary, makeindex, maketitle, mapsto, marginparpush, marginparsep,
     marginpartext, marginparwidth, markbothlhd, markrightrhd, math, max, mbox,
     mboxtext, medskip, medskipamount, mho, mid, midrule, min, minipage, mit,
-    models, month, mp, mu, multicolumnnoc, multiput, nabla, natural, ne,
+    models, month, mp, mu, multicolumn, multiput, nabla, natural, ne,
     nearrow, neg, neq, newcolumntype, newcommand, newcountercounter,
     newenvironment, newenvironmentenvname, newfontcs, newlength, newline,
     newpage, newtheorem, newtheoremenv, ni, nl, nofiles, noindent,

--- a/tests/tSimple.nim
+++ b/tests/tSimple.nim
@@ -49,6 +49,23 @@ const expFigure = """
 \end{figure}
 """
 
+const expFor = """
+\begin{tabular}{|r|l|l|l|}
+\hline
+ & a & b & c
+\\
+\hline
+\textbf{0}
+ & 1 & 2 & 3
+\\\textbf{1}
+ & 4 & 5 & 6
+\\\textbf{2}
+ & 7 & 8 & 9
+\\
+\hline
+\end{tabular}
+"""
+
 suite "LaTeX DSL simple tests":
   test "Multiple TeX statementsn":
     let res = latex:
@@ -83,6 +100,23 @@ suite "LaTeX DSL simple tests":
         figure:
           \includegraphics[width=r"0.8\textwidth"]{myImage}
     check res.strip == exp4.strip
+
+
+  test "for statements":
+    let res = latex:
+      tabular{"|r|l|l|l|"}:
+        \hline
+        for title in ["a", "b", "c"]:
+          " &" `title`
+        r"\\"
+        \hline
+        for i, v in [[1, 2, 3], [4, 5, 6], [7, 8, 9]]:
+          \textbf{`i`}
+          for v in v:
+            " &" `v`
+          r"\\"
+        \hline 
+    check res.strip == expFor.strip
 
 
   test "textwidth/height":


### PR DESCRIPTION
Hi,

I implemented support for for-loops in the DSL for myself and thought maybe it could be usefull for others to have

a simple example:
```nim
latex:
    tabular{"|r|l|l|l|"}:
      \hline
      for title in ["a", "b", "c"]:
        " &" `title`
      r"\\"
      \hline
      for i, v in [[1, 2, 3], [4, 5, 6], [7, 8, 9]]:
        \textbf{`i`}
        for v in v:
          " &" `v`
        r"\\"
      \hline 
```
compiles to
```latex
\begin{tabular}{|r|l|l|l|}
\hline
 & a & b & c
\\
\hline
\textbf{0}
 & 1 & 2 & 3
\\\textbf{1}
 & 4 & 5 & 6
\\\textbf{2}
 & 7 & 8 & 9
\\
\hline
\end{tabular}
```